### PR TITLE
fixed a bug when pausing speech

### DIFF
--- a/addon/synthDrivers/piper_neural_voices/__init__.py
+++ b/addon/synthDrivers/piper_neural_voices/__init__.py
@@ -202,7 +202,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         self._bgQueue.join()
 
     def pause(self, switch):
-        self.player.pause(switch)
+        self._player.pause(switch)
 
     def _get_rate(self):
         return self.tts.rate


### PR DESCRIPTION
Pressing SHIFT caused an error synth driver has no attribute player . This pull request fixes it.